### PR TITLE
Added additional type "direct_link" to webcast.py

### DIFF
--- a/tbaapiv3client/models/webcast.py
+++ b/tbaapiv3client/models/webcast.py
@@ -77,7 +77,7 @@ class Webcast(object):
         """
         if type is None:
             raise ValueError("Invalid value for `type`, must not be `None`")  # noqa: E501
-        allowed_values = ["youtube", "twitch", "ustream", "iframe", "html5", "rtmp", "livestream"]  # noqa: E501
+        allowed_values = ["youtube", "twitch", "ustream", "iframe", "html5", "rtmp", "livestream", "direct_link"]  # noqa: E501
         if type not in allowed_values:
             raise ValueError(
                 "Invalid value for `type` ({0}), must be one of {1}"  # noqa: E501


### PR DESCRIPTION
This fixes an error in using the api for Events.get_events_by_year(2019) where event code "2019micmp" has a webcast with type "direct_link"